### PR TITLE
Remove offending usage of min and max

### DIFF
--- a/src/coal_mine/problem_31.cljc
+++ b/src/coal_mine/problem_31.cljc
@@ -2283,9 +2283,6 @@
             [(first l)] (first l))
           )))))
 
-(defcheck solution-b1f68d26
-  partition-by max)
-
 (defcheck solution-b21d9a15
   (fn [x]
     (let [belongs? (fn [x c] (or (empty? c) (= x (first c))))
@@ -2978,9 +2975,6 @@
                         j
                         ))]
               (recur (conj xs' (repeat (- j i) xi)) j))))))))
-
-(defcheck solution-dd98348b
-  partition-by min)
 
 (defcheck solution-df10fd78
   (fn re [x]


### PR DESCRIPTION
These solutions call `min` and `max` on non-numbers which violates the specs.